### PR TITLE
[Feat] 이메일 인증용 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'capital.scalable:spring-auto-restdocs-core:2.0.11'
+
+	// 이메일 인증을 위해 JavaMailApi를 직접 사용할 수 있도록 의존성 추가
+	implementation 'javax.mail:mail:1.4.7'
+	// Spring Context Support
+	implementation 'org.springframework:spring-context-support:5.3.9'
 }
 
 spotless {


### PR DESCRIPTION
## 개요
이메일인증을 위해 의존성을 추가함

## 작업사항
- build.gradle에 이메일 인증을 위해 JavaMailApi를 직접 사용할 수 있도록 의존성 추가

## 관련 이슈
close #10 