### PR TITLE
댓글 삭제 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -72,3 +72,4 @@ include::{snippets}/sample-controller-test/샘플_단건_조회/auto-section.ado
 
 include::{snippets}/comment-controller-test/comment_저장/auto-section.adoc[]
 include::{snippets}/comment-controller-test/comment_수정/auto-section.adoc[]
+include::{snippets}/comment-controller-test/comment_삭제/auto-section.adoc[]

--- a/src/main/java/com/spring/tming/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/spring/tming/domain/comment/controller/CommentController.java
@@ -1,7 +1,9 @@
 package com.spring.tming.domain.comment.controller;
 
+import com.spring.tming.domain.comment.dto.request.CommentDeleteReq;
 import com.spring.tming.domain.comment.dto.request.CommentSaveReq;
 import com.spring.tming.domain.comment.dto.request.CommentUpdateReq;
+import com.spring.tming.domain.comment.dto.response.CommentDeleteRes;
 import com.spring.tming.domain.comment.dto.response.CommentSaveRes;
 import com.spring.tming.domain.comment.dto.response.CommentUpdateRes;
 import com.spring.tming.domain.comment.service.CommentService;
@@ -9,6 +11,7 @@ import com.spring.tming.global.response.RestResponse;
 import com.spring.tming.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,5 +38,13 @@ public class CommentController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         commentUpdateReq.setUserId(userDetails.getUser().getUserId());
         return RestResponse.success(commentService.updateComment(commentUpdateReq));
+    }
+
+    @DeleteMapping
+    public RestResponse<CommentDeleteRes> deleteComment(
+            @RequestBody CommentDeleteReq commentDeleteReq,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        commentDeleteReq.setUserId(userDetails.getUser().getUserId());
+        return RestResponse.success(commentService.deleteComment(commentDeleteReq));
     }
 }

--- a/src/main/java/com/spring/tming/domain/comment/dto/request/CommentDeleteReq.java
+++ b/src/main/java/com/spring/tming/domain/comment/dto/request/CommentDeleteReq.java
@@ -1,0 +1,21 @@
+package com.spring.tming.domain.comment.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentDeleteReq {
+    private Long commentId;
+    private Long userId;
+
+    @Builder
+    private CommentDeleteReq(Long commentId, Long userId) {
+        this.commentId = commentId;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/spring/tming/domain/comment/dto/response/CommentDeleteRes.java
+++ b/src/main/java/com/spring/tming/domain/comment/dto/response/CommentDeleteRes.java
@@ -1,0 +1,6 @@
+package com.spring.tming.domain.comment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class CommentDeleteRes {}

--- a/src/main/java/com/spring/tming/domain/comment/service/CommentService.java
+++ b/src/main/java/com/spring/tming/domain/comment/service/CommentService.java
@@ -1,7 +1,9 @@
 package com.spring.tming.domain.comment.service;
 
+import com.spring.tming.domain.comment.dto.request.CommentDeleteReq;
 import com.spring.tming.domain.comment.dto.request.CommentSaveReq;
 import com.spring.tming.domain.comment.dto.request.CommentUpdateReq;
+import com.spring.tming.domain.comment.dto.response.CommentDeleteRes;
 import com.spring.tming.domain.comment.dto.response.CommentSaveRes;
 import com.spring.tming.domain.comment.dto.response.CommentUpdateRes;
 import com.spring.tming.domain.comment.entity.Comment;
@@ -47,6 +49,16 @@ public class CommentService {
                         .post(comment.getPost())
                         .build());
         return new CommentUpdateRes();
+    }
+
+    @Transactional
+    public CommentDeleteRes deleteComment(CommentDeleteReq commentDeleteReq) {
+        Comment comment =
+                commentRepository.findByCommentIdAndUserUserId(
+                        commentDeleteReq.getCommentId(), commentDeleteReq.getUserId());
+        CommentValidator.validate(comment);
+        commentRepository.delete(comment);
+        return new CommentDeleteRes();
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/test/java/com/spring/tming/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/spring/tming/domain/comment/controller/CommentControllerTest.java
@@ -2,14 +2,17 @@ package com.spring.tming.domain.comment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.spring.tming.domain.BaseMvcTest;
+import com.spring.tming.domain.comment.dto.request.CommentDeleteReq;
 import com.spring.tming.domain.comment.dto.request.CommentSaveReq;
 import com.spring.tming.domain.comment.dto.request.CommentUpdateReq;
+import com.spring.tming.domain.comment.dto.response.CommentDeleteRes;
 import com.spring.tming.domain.comment.dto.response.CommentSaveRes;
 import com.spring.tming.domain.comment.dto.response.CommentUpdateRes;
 import com.spring.tming.domain.comment.service.CommentService;
@@ -57,6 +60,23 @@ class CommentControllerTest extends BaseMvcTest {
                         patch("/v1/comments")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(commentUpdateReq))
+                                .principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("comment 삭제 테스트")
+    void comment_삭제() throws Exception {
+        Long commentId = 1L;
+        CommentDeleteReq commentDeleteReq = CommentDeleteReq.builder().commentId(commentId).build();
+        CommentDeleteRes commentDeleteRes = new CommentDeleteRes();
+        when(commentService.deleteComment(any())).thenReturn(commentDeleteRes);
+        this.mockMvc
+                .perform(
+                        delete("/v1/comments")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(commentDeleteReq))
                                 .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());


### PR DESCRIPTION
## 개요
댓글 삭제 api를 추가합니다.

## 작업사항
- 댓글 삭제 api 추가
- 테스트코드 추가
- restdocs 추가

## 관련 이슈
- close #44  
