### PR TITLE
유저 팔로우 취소 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -72,6 +72,7 @@ include::{snippets}/sample-controller-test/샘플_단건_조회/auto-section.ado
 
 include::{snippets}/user-controller-test/유저_프로필_조회/auto-section.adoc[]
 include::{snippets}/user-controller-test/유저_팔로우/auto-section.adoc[]
+include::{snippets}/user-controller-test/유저_팔로우_취소/auto-section.adoc[]
 
 == post API
 

--- a/src/main/java/com/spring/tming/domain/user/controller/UserController.java
+++ b/src/main/java/com/spring/tming/domain/user/controller/UserController.java
@@ -2,14 +2,17 @@ package com.spring.tming.domain.user.controller;
 
 import com.spring.tming.domain.user.dto.request.FollowReq;
 import com.spring.tming.domain.user.dto.request.SignupReq;
+import com.spring.tming.domain.user.dto.request.UnfollowReq;
 import com.spring.tming.domain.user.dto.response.FollowRes;
 import com.spring.tming.domain.user.dto.response.SignupRes;
+import com.spring.tming.domain.user.dto.response.UnfollowRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
 import com.spring.tming.domain.user.service.UserService;
 import com.spring.tming.global.response.RestResponse;
 import com.spring.tming.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,5 +42,12 @@ public class UserController {
             @RequestBody FollowReq followReq, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         followReq.setFollowerId(userDetails.getUser().getUserId());
         return RestResponse.success(userService.followUser(followReq));
+    }
+
+    @DeleteMapping("/unfollow")
+    public RestResponse<UnfollowRes> unfollowUser(
+            @RequestBody UnfollowReq unfollowReq, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        unfollowReq.setFollowerId(userDetails.getUser().getUserId());
+        return RestResponse.success(userService.unfollowUser(unfollowReq));
     }
 }

--- a/src/main/java/com/spring/tming/domain/user/dto/request/UnfollowReq.java
+++ b/src/main/java/com/spring/tming/domain/user/dto/request/UnfollowReq.java
@@ -1,0 +1,21 @@
+package com.spring.tming.domain.user.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnfollowReq {
+    private Long followerId;
+    private Long followingId;
+
+    @Builder
+    private UnfollowReq(Long followerId, Long followingId) {
+        this.followerId = followerId;
+        this.followingId = followingId;
+    }
+}

--- a/src/main/java/com/spring/tming/domain/user/dto/response/UnfollowRes.java
+++ b/src/main/java/com/spring/tming/domain/user/dto/response/UnfollowRes.java
@@ -1,0 +1,6 @@
+package com.spring.tming.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties
+public class UnfollowRes {}

--- a/src/main/java/com/spring/tming/domain/user/service/UserService.java
+++ b/src/main/java/com/spring/tming/domain/user/service/UserService.java
@@ -2,8 +2,10 @@ package com.spring.tming.domain.user.service;
 
 import com.spring.tming.domain.user.dto.request.FollowReq;
 import com.spring.tming.domain.user.dto.request.SignupReq;
+import com.spring.tming.domain.user.dto.request.UnfollowReq;
 import com.spring.tming.domain.user.dto.response.FollowRes;
 import com.spring.tming.domain.user.dto.response.SignupRes;
+import com.spring.tming.domain.user.dto.response.UnfollowRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
 import com.spring.tming.domain.user.entity.Follow;
 import com.spring.tming.domain.user.entity.User;
@@ -63,6 +65,16 @@ public class UserService {
         UserValidator.checkAlreadyFollowed(follow);
         followRepository.save(Follow.builder().follower(follower).following(following).build());
         return new FollowRes();
+    }
+
+    @Transactional
+    public UnfollowRes unfollowUser(UnfollowReq unfollowReq) {
+        User follower = getUserByUserId(unfollowReq.getFollowerId());
+        User following = getUserByUserId(unfollowReq.getFollowingId());
+        Follow follow = followRepository.findByFollowerAndFollowing(follower, following);
+        UserValidator.checkNotYetFollowed(follow);
+        followRepository.delete(follow);
+        return new UnfollowRes();
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/main/java/com/spring/tming/global/meta/ResultCode.java
+++ b/src/main/java/com/spring/tming/global/meta/ResultCode.java
@@ -28,6 +28,7 @@ public enum ResultCode {
     VALID_USERNAME(3003, "username은 4자 이상, 12자 이하인 대소문자, 숫자, 한글로 구성되어야 합니다."),
     VALID_PASSWORD(3004, "password는 8자 이상, 16자 이하인 대소문자, 숫자, 특수문자를 모두 포함하여 구성되어야 합니다."),
     ALREADY_FOLLOWED_USER(3005, "이미 팔로우한 유저입니다."),
+    NOT_YET_FOLLOWED_USER(3006, "아직 팔로우하지 않은 유저입니다."),
 
     NOT_FOUND_POST(4002, "모집글 데이터가 없습니다."),
     ALREADY_LIKED_POST(4003, "이미 좋아요가 눌린 모집글입니다."),

--- a/src/main/java/com/spring/tming/global/validator/UserValidator.java
+++ b/src/main/java/com/spring/tming/global/validator/UserValidator.java
@@ -43,6 +43,12 @@ public class UserValidator {
         }
     }
 
+    public static void checkNotYetFollowed(Follow follow) {
+        if (!isExistFollow(follow)) {
+            throw new GlobalException(NOT_YET_FOLLOWED_USER);
+        }
+    }
+
     private static boolean isExistFollow(Follow follow) {
         return follow != null;
     }

--- a/src/test/java/com/spring/tming/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spring/tming/domain/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.spring.tming.domain.user.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -9,7 +10,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.spring.tming.domain.BaseMvcTest;
 import com.spring.tming.domain.user.dto.request.FollowReq;
+import com.spring.tming.domain.user.dto.request.UnfollowReq;
 import com.spring.tming.domain.user.dto.response.FollowRes;
+import com.spring.tming.domain.user.dto.response.UnfollowRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
 import com.spring.tming.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +63,23 @@ class UserControllerTest extends BaseMvcTest {
                         post("/v1/users/follow")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(followReq))
+                                .principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유저 팔로우 취소 테스트")
+    void 유저_팔로우_취소() throws Exception {
+        Long followingId = 1L;
+        UnfollowReq unfollowReq = UnfollowReq.builder().followingId(followingId).build();
+        UnfollowRes unfollowRes = new UnfollowRes();
+        when(userService.unfollowUser(any())).thenReturn(unfollowRes);
+        this.mockMvc
+                .perform(
+                        delete("/v1/users/unfollow")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(unfollowReq))
                                 .principal(this.mockPrincipal))
                 .andDo(print())
                 .andExpect(status().isOk());


### PR DESCRIPTION
## 개요
유저 팔로우 취소 api를 추가합니다.

## 작업사항
- 유저 팔로우 취소 api 추가
- controller 테스트코드 추가
- restdocs 추가

## 관련 이슈
- close #69 
