### PR TITLE
유저 팔로워 목록 조회 api 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -73,6 +73,7 @@ include::{snippets}/sample-controller-test/샘플_단건_조회/auto-section.ado
 include::{snippets}/user-controller-test/유저_프로필_조회/auto-section.adoc[]
 include::{snippets}/user-controller-test/유저_팔로우/auto-section.adoc[]
 include::{snippets}/user-controller-test/유저_팔로우_취소/auto-section.adoc[]
+include::{snippets}/user-controller-test/유저_팔로워_전체_조회/auto-section.adoc[]
 
 == post API
 

--- a/src/main/java/com/spring/tming/domain/user/controller/UserController.java
+++ b/src/main/java/com/spring/tming/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.spring.tming.domain.user.dto.request.FollowReq;
 import com.spring.tming.domain.user.dto.request.SignupReq;
 import com.spring.tming.domain.user.dto.request.UnfollowReq;
 import com.spring.tming.domain.user.dto.response.FollowRes;
+import com.spring.tming.domain.user.dto.response.FollowerGetResList;
 import com.spring.tming.domain.user.dto.response.SignupRes;
 import com.spring.tming.domain.user.dto.response.UnfollowRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
@@ -49,5 +50,10 @@ public class UserController {
             @RequestBody UnfollowReq unfollowReq, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         unfollowReq.setFollowerId(userDetails.getUser().getUserId());
         return RestResponse.success(userService.unfollowUser(unfollowReq));
+    }
+
+    @GetMapping("/follower/{userId}")
+    public RestResponse<FollowerGetResList> getFollowers(@PathVariable Long userId) {
+        return RestResponse.success(userService.getFollowers(userId));
     }
 }

--- a/src/main/java/com/spring/tming/domain/user/dto/response/FollowerGetRes.java
+++ b/src/main/java/com/spring/tming/domain/user/dto/response/FollowerGetRes.java
@@ -1,0 +1,21 @@
+package com.spring.tming.domain.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FollowerGetRes {
+    private Long userId;
+    private String username;
+    private String profileImageUrl;
+
+    @Builder
+    private FollowerGetRes(Long userId, String username, String profileImageUrl) {
+        this.userId = userId;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/spring/tming/domain/user/dto/response/FollowerGetResList.java
+++ b/src/main/java/com/spring/tming/domain/user/dto/response/FollowerGetResList.java
@@ -1,0 +1,20 @@
+package com.spring.tming.domain.user.dto.response;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FollowerGetResList {
+    private List<FollowerGetRes> followers;
+    private int total;
+
+    @Builder
+    private FollowerGetResList(List<FollowerGetRes> followers, int total) {
+        this.followers = followers;
+        this.total = total;
+    }
+}

--- a/src/main/java/com/spring/tming/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/spring/tming/domain/user/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.spring.tming.domain.user.repository;
 
 import com.spring.tming.domain.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +15,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByEmailOrUsername(String email, String username);
 
     User findByUsername(String username);
+
+    @Query(
+            value =
+                    "select u from User u "
+                            + "join Follow f on f.follower.userId=u.userId "
+                            + "where u.userId=:userId")
+    List<User> findFollowers(Long userId);
 }

--- a/src/main/java/com/spring/tming/domain/user/service/UserService.java
+++ b/src/main/java/com/spring/tming/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import com.spring.tming.domain.user.dto.request.FollowReq;
 import com.spring.tming.domain.user.dto.request.SignupReq;
 import com.spring.tming.domain.user.dto.request.UnfollowReq;
 import com.spring.tming.domain.user.dto.response.FollowRes;
+import com.spring.tming.domain.user.dto.response.FollowerGetRes;
+import com.spring.tming.domain.user.dto.response.FollowerGetResList;
 import com.spring.tming.domain.user.dto.response.SignupRes;
 import com.spring.tming.domain.user.dto.response.UnfollowRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
@@ -14,6 +16,7 @@ import com.spring.tming.domain.user.repository.UserRepository;
 import com.spring.tming.global.entity.Role;
 import com.spring.tming.global.validator.EmailCheckValidator;
 import com.spring.tming.global.validator.UserValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -75,6 +78,16 @@ public class UserService {
         UserValidator.checkNotYetFollowed(follow);
         followRepository.delete(follow);
         return new UnfollowRes();
+    }
+
+    @Transactional(readOnly = true)
+    public FollowerGetResList getFollowers(Long userId) {
+        List<FollowerGetRes> followerGetReses =
+                UserServiceMapper.INSTANCE.toFollowerGetResList(userRepository.findFollowers(userId));
+        return FollowerGetResList.builder()
+                .followers(followerGetReses)
+                .total(followerGetReses.size())
+                .build();
     }
 
     private User getUserByUserId(Long userId) {

--- a/src/main/java/com/spring/tming/domain/user/service/UserServiceMapper.java
+++ b/src/main/java/com/spring/tming/domain/user/service/UserServiceMapper.java
@@ -1,7 +1,9 @@
 package com.spring.tming.domain.user.service;
 
+import com.spring.tming.domain.user.dto.response.FollowerGetRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
 import com.spring.tming.domain.user.entity.User;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -14,4 +16,6 @@ public interface UserServiceMapper {
     // TODO add follower, following cnt
     @Mapping(source = "job.description", target = "job")
     UserGetRes toUserGetRes(User user);
+
+    List<FollowerGetRes> toFollowerGetResList(List<User> users);
 }

--- a/src/test/java/com/spring/tming/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/spring/tming/domain/user/controller/UserControllerTest.java
@@ -12,9 +12,12 @@ import com.spring.tming.domain.BaseMvcTest;
 import com.spring.tming.domain.user.dto.request.FollowReq;
 import com.spring.tming.domain.user.dto.request.UnfollowReq;
 import com.spring.tming.domain.user.dto.response.FollowRes;
+import com.spring.tming.domain.user.dto.response.FollowerGetRes;
+import com.spring.tming.domain.user.dto.response.FollowerGetResList;
 import com.spring.tming.domain.user.dto.response.UnfollowRes;
 import com.spring.tming.domain.user.dto.response.UserGetRes;
 import com.spring.tming.domain.user.service.UserService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -81,6 +84,28 @@ class UserControllerTest extends BaseMvcTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(unfollowReq))
                                 .principal(this.mockPrincipal))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유저 팔로워 전체 조회 테스트")
+    void 유저_팔로워_전체_조회() throws Exception {
+        Long userId = 1L;
+        Long followerId = 2L;
+        String username = "ysys";
+        String profileImageUrl = "url";
+        FollowerGetRes followerGetRes =
+                FollowerGetRes.builder()
+                        .userId(followerId)
+                        .username(username)
+                        .profileImageUrl(profileImageUrl)
+                        .build();
+        FollowerGetResList followerGetResList =
+                FollowerGetResList.builder().followers(List.of(followerGetRes)).total(1).build();
+        when(userService.getFollowers(any())).thenReturn(followerGetResList);
+        this.mockMvc
+                .perform(get("/v1/users/follower/" + userId))
                 .andDo(print())
                 .andExpect(status().isOk());
     }


### PR DESCRIPTION
## 개요
유저 팔로워 목록 조회 api를 추가합니다.

## 작업사항
- 유저 팔로워 목록 조회 api 추가
- controller 테스트코드 추가
- restdocs 추가

## 관련 이슈
- close #73 
