### PR TITLE
이미 팔로우한 유저인지 확인로직 추가

### DIFF
--- a/src/main/java/com/spring/tming/domain/user/dto/response/UserGetRes.java
+++ b/src/main/java/com/spring/tming/domain/user/dto/response/UserGetRes.java
@@ -16,6 +16,7 @@ public class UserGetRes {
     private int following;
     private int follower;
     private String profileImageUrl;
+    private Boolean followed;
 
     @Builder
     private UserGetRes(
@@ -26,7 +27,8 @@ public class UserGetRes {
             String introduce,
             int following,
             int follower,
-            String profileImageUrl) {
+            String profileImageUrl,
+            boolean followed) {
         this.userId = userId;
         this.email = email;
         this.username = username;
@@ -35,5 +37,6 @@ public class UserGetRes {
         this.following = following;
         this.follower = follower;
         this.profileImageUrl = profileImageUrl;
+        this.followed = followed;
     }
 }

--- a/src/main/java/com/spring/tming/domain/user/service/UserServiceMapper.java
+++ b/src/main/java/com/spring/tming/domain/user/service/UserServiceMapper.java
@@ -17,6 +17,16 @@ public interface UserServiceMapper {
 
     UserServiceMapper INSTANCE = Mappers.getMapper(UserServiceMapper.class);
 
+    @Mapping(source = "user", target = "followed")
+    default boolean toIsFollowed(User user) {
+        if (CollectionUtils.isEmpty(user.getFollowers())) {
+            return false;
+        }
+
+        return user.getFollowers().stream()
+                .anyMatch(follow -> user.getUserId().equals(follow.getFollower().getUserId()));
+    }
+
     @Mapping(source = "followings", target = "following")
     @Mapping(source = "followers", target = "follower")
     default int toFollowCnt(List<Follow> follows) {
@@ -26,6 +36,7 @@ public interface UserServiceMapper {
         return follows.size();
     }
 
+    @Mapping(source = "user", target = "followed")
     @Mapping(source = "followers", target = "follower")
     @Mapping(source = "followings", target = "following")
     @Mapping(source = "job.description", target = "job")


### PR DESCRIPTION
## 개요
유저 프로필 조회 시 이미 팔로우한 유저인지 확인하는 로직을 추가합니다.

## 작업사항
- UserGetRes에 `followed` 변수 추가

## 관련 이슈
- close #109 
